### PR TITLE
Merge Servotech BugFixes 17052024 into Updated Develop

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,10 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
+    <queries>
+        <package android:name="com.EVSEReady.charger_helper" />
+    </queries>
+
     <application
         android:name=".HMIApp"
         android:allowBackup="true"
@@ -46,7 +50,7 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name= "android.intent.category.HOME" />
-                <!--<category android:name= "android.intent.category.DEFAULT" />-->
+                <category android:name= "android.intent.category.DEFAULT" />
                 <category android:name= "android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
@@ -57,6 +61,7 @@
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.QUICKBOOT_POWERON" />
                 <category android:name="android.intent.category.HOME" />
             </intent-filter>
         </receiver>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -50,7 +50,7 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name= "android.intent.category.HOME" />
-                <category android:name= "android.intent.category.DEFAULT" />
+                <!--<category android:name= "android.intent.category.DEFAULT" />-->
                 <category android:name= "android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>

--- a/app/src/main/java/com/bacancy/ccs2androidhmi/base/SerialPortBaseActivityNew.kt
+++ b/app/src/main/java/com/bacancy/ccs2androidhmi/base/SerialPortBaseActivityNew.kt
@@ -1049,7 +1049,7 @@ abstract class SerialPortBaseActivityNew : AppCompatActivity() {
                 } else {
                     writeForGunsRectifier(
                         359,
-                        prefHelper.getIntValue("GUN1_OUTPUT_ON_OFF_VALUE", 0)
+                        prefHelper.getIntValue("GUN2_OUTPUT_ON_OFF_VALUE", 0)
                     )
                 }
             } else {

--- a/app/src/main/java/com/bacancy/ccs2androidhmi/base/SerialPortBaseActivityNew.kt
+++ b/app/src/main/java/com/bacancy/ccs2androidhmi/base/SerialPortBaseActivityNew.kt
@@ -28,8 +28,8 @@ import com.bacancy.ccs2androidhmi.util.CommonUtils.GUN_2_DC_METER_FRAG
 import com.bacancy.ccs2androidhmi.util.CommonUtils.GUN_2_LAST_CHARGING_SUMMARY_FRAG
 import com.bacancy.ccs2androidhmi.util.CommonUtils.GUN_2_LOCAL_START
 import com.bacancy.ccs2androidhmi.util.CommonUtils.INSIDE_LOCAL_START_STOP_SCREEN
+import com.bacancy.ccs2androidhmi.util.CommonUtils.IS_APP_RESTARTED
 import com.bacancy.ccs2androidhmi.util.CommonUtils.IS_CHARGER_ACTIVE
-import com.bacancy.ccs2androidhmi.util.CommonUtils.IS_INITIAL_CHARGER_DETAILS_PUBLISHED
 import com.bacancy.ccs2androidhmi.util.CommonUtils.UNIT_PRICE
 import com.bacancy.ccs2androidhmi.util.CommonUtils.addColonsToMacAddress
 import com.bacancy.ccs2androidhmi.util.CommonUtils.generateRandomNumber
@@ -65,6 +65,7 @@ import com.bacancy.ccs2androidhmi.util.ModBusUtils
 import com.bacancy.ccs2androidhmi.util.ModbusRequestFrames
 import com.bacancy.ccs2androidhmi.util.ModbusTypeConverter
 import com.bacancy.ccs2androidhmi.util.ModbusTypeConverter.toHex
+import com.bacancy.ccs2androidhmi.util.NetworkUtils.isInternetConnected
 import com.bacancy.ccs2androidhmi.util.PrefHelper
 import com.bacancy.ccs2androidhmi.util.ReadWriteUtil
 import com.bacancy.ccs2androidhmi.util.ResponseSizes
@@ -382,25 +383,27 @@ abstract class SerialPortBaseActivityNew : AppCompatActivity() {
     }
 
     private fun sendInitialChargerDetailsToServer() {
-        if (prefHelper.getBoolean(IS_INITIAL_CHARGER_DETAILS_PUBLISHED, false)) return
+        if (prefHelper.getBoolean(IS_APP_RESTARTED, false)) {
+            val deviceMacAddress = prefHelper.getStringValue(DEVICE_MAC_ADDRESS, "")
+            val chargerRatings = prefHelper.getStringValue(CHARGER_RATINGS, "")
+            val chargerOutputs = prefHelper.getStringValue(CHARGER_OUTPUTS, "")
+            val unitPrice = prefHelper.getStringValue(UNIT_PRICE, "")
 
-        val deviceMacAddress = prefHelper.getStringValue(DEVICE_MAC_ADDRESS, "")
-        val chargerRatings = prefHelper.getStringValue(CHARGER_RATINGS, "")
-        val chargerOutputs = prefHelper.getStringValue(CHARGER_OUTPUTS, "")
-        val unitPrice = prefHelper.getStringValue(UNIT_PRICE, "")
-
-        if (deviceMacAddress.isNotEmpty() && chargerRatings.isNotEmpty() && chargerOutputs.isNotEmpty()) {
-            val initialChargerDetails = mqttViewModel.getInitialChargerDetails(
-                deviceMacAddress,
-                chargerRatings,
-                chargerOutputs,
-                unitPrice
-            )
-            mqttViewModel.publishMessageToTopic(
-                initialChargerDetails.first,
-                initialChargerDetails.second
-            )
-            prefHelper.setBoolean(IS_INITIAL_CHARGER_DETAILS_PUBLISHED, true)
+            if (deviceMacAddress.isNotEmpty() && chargerRatings.isNotEmpty() && chargerOutputs.isNotEmpty()) {
+                val initialChargerDetails = mqttViewModel.getInitialChargerDetails(
+                    deviceMacAddress,
+                    chargerRatings,
+                    chargerOutputs,
+                    unitPrice
+                )
+                if(isInternetConnected()){
+                    mqttViewModel.publishMessageToTopic(
+                        initialChargerDetails.first,
+                        initialChargerDetails.second
+                    )
+                    prefHelper.setBoolean(IS_APP_RESTARTED, false)
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/bacancy/ccs2androidhmi/base/SerialPortBaseActivityNew.kt
+++ b/app/src/main/java/com/bacancy/ccs2androidhmi/base/SerialPortBaseActivityNew.kt
@@ -127,7 +127,7 @@ abstract class SerialPortBaseActivityNew : AppCompatActivity() {
         setupPortsAndStartReading()
     }
 
-    private fun setupPortsAndStartReading() {
+    fun setupPortsAndStartReading() {
         setupSerialPort()
         startReading()
     }
@@ -146,7 +146,7 @@ abstract class SerialPortBaseActivityNew : AppCompatActivity() {
         super.onPause()
     }
 
-    private fun resetPorts() {
+    fun resetPorts() {
         mApplication?.closeSerialPort()
         mSerialPort = null
         mOutputStream = null

--- a/app/src/main/java/com/bacancy/ccs2androidhmi/db/AppDatabase.kt
+++ b/app/src/main/java/com/bacancy/ccs2androidhmi/db/AppDatabase.kt
@@ -17,7 +17,7 @@ import com.bacancy.ccs2androidhmi.db.entity.TbNotifications
 @Database(
     entities = [TbChargingHistory::class, TbAcMeterInfo::class, TbMiscInfo::class, TbGunsDcMeterInfo::class, TbGunsChargingInfo::class, TbGunsLastChargingSummary::class,
                TbErrorCodes::class, TbNotifications::class],
-    version = 4
+    version = 5
 )
 abstract class AppDatabase : RoomDatabase() {
 
@@ -41,6 +41,12 @@ abstract class AppDatabase : RoomDatabase() {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE tbGunsChargingInfo ADD COLUMN gunTemperatureDCPositive REAL DEFAULT 0.0 NOT NULL")
                 db.execSQL("ALTER TABLE tbGunsChargingInfo ADD COLUMN gunTemperatureDCNegative REAL DEFAULT 0.0 NOT NULL")
+            }
+        }
+
+        val MIGRATION_4_5: Migration = object : Migration(4, 5) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE tbGunsLastChargingSummary ADD COLUMN totalCost TEXT DEFAULT '' NOT NULL")
             }
         }
 

--- a/app/src/main/java/com/bacancy/ccs2androidhmi/db/dao/AppDao.kt
+++ b/app/src/main/java/com/bacancy/ccs2androidhmi/db/dao/AppDao.kt
@@ -63,7 +63,10 @@ interface AppDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertErrorCode(tbErrorCodes: TbErrorCodes): Long
 
-    @Query("SELECT * FROM tbErrorCodes")
+    @Query("SELECT * FROM tbErrorCodes WHERE sourceId = :sourceId AND sourceErrorCodes = :sourceErrorCodes")
+    fun getErrorCodeFromDB(sourceId: Int, sourceErrorCodes: String): List<TbErrorCodes>
+
+    @Query("SELECT * FROM tbErrorCodes ORDER BY id DESC")
     fun getAllErrorCodes(): LiveData<List<TbErrorCodes>>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)

--- a/app/src/main/java/com/bacancy/ccs2androidhmi/db/entity/TbErrorCodes.kt
+++ b/app/src/main/java/com/bacancy/ccs2androidhmi/db/entity/TbErrorCodes.kt
@@ -7,5 +7,6 @@ import androidx.room.PrimaryKey
 data class TbErrorCodes(
     @PrimaryKey
     var sourceId: Int,
-    var sourceErrorCodes: String
+    var sourceErrorCodes: String,
+    var sourceErrorDateTime: String,
 )

--- a/app/src/main/java/com/bacancy/ccs2androidhmi/db/entity/TbErrorCodes.kt
+++ b/app/src/main/java/com/bacancy/ccs2androidhmi/db/entity/TbErrorCodes.kt
@@ -5,8 +5,10 @@ import androidx.room.PrimaryKey
 
 @Entity(tableName = "tbErrorCodes")
 data class TbErrorCodes(
-    @PrimaryKey
-    var sourceId: Int,
-    var sourceErrorCodes: String,
-    var sourceErrorDateTime: String,
+    @PrimaryKey(autoGenerate = true)
+    var id: Int? = null,
+    var sourceId: Int,//0,1,2
+    var sourceErrorCodes: String,//EMG_PRESSED, etc
+    var sourceErrorValue: Int,//1,0
+    var sourceErrorDateTime: String,//2021-09-01 12:00:00
 )

--- a/app/src/main/java/com/bacancy/ccs2androidhmi/db/entity/TbGunsLastChargingSummary.kt
+++ b/app/src/main/java/com/bacancy/ccs2androidhmi/db/entity/TbGunsLastChargingSummary.kt
@@ -14,5 +14,6 @@ data class TbGunsLastChargingSummary(
     var startSoc: String,
     var endSoc: String,
     var energyConsumption: String,
-    var sessionEndReason: String
+    var sessionEndReason: String,
+    var totalCost: String
 )

--- a/app/src/main/java/com/bacancy/ccs2androidhmi/di/DatabaseModule.kt
+++ b/app/src/main/java/com/bacancy/ccs2androidhmi/di/DatabaseModule.kt
@@ -6,6 +6,7 @@ import com.bacancy.ccs2androidhmi.db.AppDatabase
 import com.bacancy.ccs2androidhmi.db.AppDatabase.Companion.MIGRATION_1_2
 import com.bacancy.ccs2androidhmi.db.AppDatabase.Companion.MIGRATION_2_3
 import com.bacancy.ccs2androidhmi.db.AppDatabase.Companion.MIGRATION_3_4
+import com.bacancy.ccs2androidhmi.db.AppDatabase.Companion.MIGRATION_4_5
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -21,7 +22,7 @@ object DatabaseModule {
     @Provides
     fun provideAppDatabase(@ApplicationContext appContext: Context): AppDatabase {
         return Room.databaseBuilder(appContext, AppDatabase::class.java, "CCS2_HMI.db")
-            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4)
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5)
             .build()
     }
 

--- a/app/src/main/java/com/bacancy/ccs2androidhmi/models/ErrorCodes.kt
+++ b/app/src/main/java/com/bacancy/ccs2androidhmi/models/ErrorCodes.kt
@@ -1,8 +1,10 @@
 package com.bacancy.ccs2androidhmi.models
 
 data class ErrorCodes(
-    val id: Int,
+    val id: Int? = null,
     val errorCodeName: String,
+    val errorCodeSource: String,
     val errorCodeStatus: String,
+    val errorCodeValue: Int,
     val errorCodeDateTime: String,
 )

--- a/app/src/main/java/com/bacancy/ccs2androidhmi/models/ErrorCodes.kt
+++ b/app/src/main/java/com/bacancy/ccs2androidhmi/models/ErrorCodes.kt
@@ -4,4 +4,5 @@ data class ErrorCodes(
     val id: Int,
     val errorCodeName: String,
     val errorCodeStatus: String,
+    val errorCodeDateTime: String,
 )

--- a/app/src/main/java/com/bacancy/ccs2androidhmi/repository/MainRepository.kt
+++ b/app/src/main/java/com/bacancy/ccs2androidhmi/repository/MainRepository.kt
@@ -74,6 +74,10 @@ class MainRepository @Inject constructor(private val appDatabase: AppDatabase) {
         appDatabase.appDao().insertErrorCode(tbErrorCodes)
     }
 
+    fun getErrorCodeFromDB(sourceId: Int, sourceErrorCodes: String): List<TbErrorCodes> {
+        return appDatabase.appDao().getErrorCodeFromDB(sourceId, sourceErrorCodes)
+    }
+
     fun getAllErrorCodes(): LiveData<List<TbErrorCodes>> {
         return appDatabase.appDao().getAllErrorCodes()
     }

--- a/app/src/main/java/com/bacancy/ccs2androidhmi/util/CommonUtils.kt
+++ b/app/src/main/java/com/bacancy/ccs2androidhmi/util/CommonUtils.kt
@@ -31,10 +31,12 @@ object CommonUtils {
     const val DEVICE_MAC_ADDRESS = "DEVICE_MAC_ADDRESS"
     const val CHARGER_RATINGS = "CHARGER_RATINGS"
     const val CHARGER_OUTPUTS = "CHARGER_OUTPUTS"
-    const val IS_INITIAL_CHARGER_DETAILS_PUBLISHED = "IS_INITIAL_CHARGER_DETAILS_PUBLISHED"
+    const val IS_APP_RESTARTED = "IS_APP_RESTARTED"
     const val UNIT_PRICE = "UNIT_PRICE"
     const val IS_CHARGER_ACTIVE="IS_CHARGER_ACTIVE"
     const val CHARGER_ACTIVE_DEACTIVE_MESSAGE_RECD = "CHARGER_MSG_RECD"
+    const val IS_APP_PINNED = "IS_APP_PINNED"
+    const val EVSE_APP_PACKAGE_NAME="com.EVSEReady.charger_helper"
 
     private fun swapAdjacentElements(array: MutableList<Int>): MutableList<Int> {
         for (i in 0 until array.size - 1 step 2) {

--- a/app/src/main/java/com/bacancy/ccs2androidhmi/util/DateTimeUtils.kt
+++ b/app/src/main/java/com/bacancy/ccs2androidhmi/util/DateTimeUtils.kt
@@ -7,7 +7,9 @@ import java.util.Locale
 
 object DateTimeUtils {
 
-    private const val DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX"
+    const val DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX"
+    const val DATE_TIME_FORMAT_FOR_UI = "dd-MM-yyyy HH:mm:ss"
+    const val DATE_TIME_FORMAT_FROM_CHARGER = "dd/MM/yyyy HH:mm:ss"
 
     fun getCurrentDateTime(dateTimeFormat: String = DATE_TIME_FORMAT): String {
         val now = System.currentTimeMillis()
@@ -15,10 +17,10 @@ object DateTimeUtils {
         return formatter.format(now)
     }
 
-    fun String.convertDateFormat(): String {
+    fun String.convertDateFormatToDesiredFormat(currentFormat: String, desiredFormat: String): String {
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val originalFormatter = SimpleDateFormat("dd/MM/yyyy HH:mm:ss", Locale.getDefault())
-            val targetFormatter = SimpleDateFormat(DATE_TIME_FORMAT, Locale.getDefault())
+            val originalFormatter = SimpleDateFormat(currentFormat, Locale.getDefault())
+            val targetFormatter = SimpleDateFormat(desiredFormat, Locale.getDefault())
 
             // Parse the original date string
             val date = originalFormatter.parse(this)

--- a/app/src/main/java/com/bacancy/ccs2androidhmi/util/DialogUtils.kt
+++ b/app/src/main/java/com/bacancy/ccs2androidhmi/util/DialogUtils.kt
@@ -265,6 +265,7 @@ object DialogUtils {
     }
 
     fun Activity.showPasswordPromptDialog(
+        popupTitle: String = "Authorize",
         onSuccess: () -> Unit,
         onFailed: () -> Unit
     ) {
@@ -274,6 +275,7 @@ object DialogUtils {
         dialog.setContentView(binding.root)
 
         binding.apply {
+            tvPopupTitle.text = popupTitle
             btnSubmit.setOnClickListener {
                 dialog.dismiss()
                 val enteredPassword = edtPassword.text.toString()

--- a/app/src/main/java/com/bacancy/ccs2androidhmi/util/DialogUtils.kt
+++ b/app/src/main/java/com/bacancy/ccs2androidhmi/util/DialogUtils.kt
@@ -222,6 +222,11 @@ object DialogUtils {
             incSessionEndReason.tvSummaryValue.text = ""
             incSessionEndReason.root.setBackgroundColor(resources.getColor(if (isDarkTheme) R.color.black else R.color.white))
 
+            incSessionTotalCost.tvSummaryLabel.text = getString(R.string.lbl_total_cost)
+            incSessionTotalCost.tvSummaryUnit.invisible()
+            incSessionTotalCost.tvSummaryValue.text = ""
+            incSessionTotalCost.root.setBackgroundColor(resources.getColor(R.color.light_trans_sky_blue))
+
             tvGunsHeader.text =
                 if (isGun1) "Gun - 1 Charging Summary" else "Gun - 2 Charging Summary"
             tbGunsLastChargingSummary.apply {
@@ -233,6 +238,7 @@ object DialogUtils {
                 incEndSOC.tvSummaryValue.text = endSoc
                 incEnergyConsumption.tvSummaryValue.text = energyConsumption
                 incSessionEndReason.tvSummaryValue.text = sessionEndReason
+                incSessionTotalCost.tvSummaryValue.text = getString(R.string.lbl_gun_total_cost_in_rs, if(totalCost.isEmpty()) 0.0F else totalCost.toFloat())
             }
             btnClose.setOnClickListener {
                 dialog.dismiss()

--- a/app/src/main/java/com/bacancy/ccs2androidhmi/viewmodel/AppViewModel.kt
+++ b/app/src/main/java/com/bacancy/ccs2androidhmi/viewmodel/AppViewModel.kt
@@ -223,7 +223,8 @@ class AppViewModel @Inject constructor(private val mainRepository: MainRepositor
                 ),
                 sessionEndReason = LastChargingSummaryUtils.getSessionEndReason(
                     it
-                )
+                ),
+                totalCost = LastChargingSummaryUtils.getTotalCost(it)
             )
         )
     }
@@ -317,7 +318,8 @@ class AppViewModel @Inject constructor(private val mainRepository: MainRepositor
                 ),
                 sessionEndReason = LastChargingSummaryUtils.getSessionEndReason(
                     it
-                )
+                ),
+                totalCost = LastChargingSummaryUtils.getTotalCost(it)
             )
         )
     }

--- a/app/src/main/java/com/bacancy/ccs2androidhmi/viewmodel/MQTTViewModel.kt
+++ b/app/src/main/java/com/bacancy/ccs2androidhmi/viewmodel/MQTTViewModel.kt
@@ -285,7 +285,7 @@ class MQTTViewModel @Inject constructor(private val mqttClient: MQTTClient) : Vi
     ) {
         if(updatedErrorCodesList.isNotEmpty()){
             updatedErrorCodesList.forEach { error ->
-                val connectorId = when (error.errorCodeStatus) {
+                val connectorId = when (error.errorCodeSource) {
                     "Charger" -> 0
                     "Gun 1" -> 1
                     "Gun 2" -> 2

--- a/app/src/main/java/com/bacancy/ccs2androidhmi/viewmodel/MQTTViewModel.kt
+++ b/app/src/main/java/com/bacancy/ccs2androidhmi/viewmodel/MQTTViewModel.kt
@@ -13,7 +13,9 @@ import com.bacancy.ccs2androidhmi.mqtt.models.FaultErrorsBody
 import com.bacancy.ccs2androidhmi.util.CommonUtils.addColonsToMacAddress
 import com.bacancy.ccs2androidhmi.util.CommonUtils.toJsonString
 import com.bacancy.ccs2androidhmi.util.DateTimeUtils
-import com.bacancy.ccs2androidhmi.util.DateTimeUtils.convertDateFormat
+import com.bacancy.ccs2androidhmi.util.DateTimeUtils.DATE_TIME_FORMAT
+import com.bacancy.ccs2androidhmi.util.DateTimeUtils.DATE_TIME_FORMAT_FROM_CHARGER
+import com.bacancy.ccs2androidhmi.util.DateTimeUtils.convertDateFormatToDesiredFormat
 import com.bacancy.ccs2androidhmi.util.DateTimeUtils.convertToUtc
 import com.bacancy.ccs2androidhmi.util.LastChargingSummaryUtils
 import com.bacancy.ccs2androidhmi.util.Resource
@@ -231,8 +233,8 @@ class MQTTViewModel @Inject constructor(private val mqttClient: MQTTClient) : Vi
             connectorId = connectorId,
             evMacAddress = LastChargingSummaryUtils.getEVMacAddress(it),
             chargingStartTime = LastChargingSummaryUtils.getChargingStartTime(it)
-                .convertDateFormat().convertToUtc().orEmpty(),
-            chargingEndTime = LastChargingSummaryUtils.getChargingEndTime(it).convertDateFormat().convertToUtc().orEmpty(),
+                .convertDateFormatToDesiredFormat(currentFormat = DATE_TIME_FORMAT_FROM_CHARGER, desiredFormat = DATE_TIME_FORMAT).convertToUtc().orEmpty(),
+            chargingEndTime = LastChargingSummaryUtils.getChargingEndTime(it).convertDateFormatToDesiredFormat(currentFormat = DATE_TIME_FORMAT_FROM_CHARGER, desiredFormat = DATE_TIME_FORMAT).convertToUtc().orEmpty(),
             totalChargingTime = LastChargingSummaryUtils.getTotalChargingTime(it),
             startSoc = LastChargingSummaryUtils.getStartSoc(it),
             endSoc = LastChargingSummaryUtils.getEndSoc(it),

--- a/app/src/main/java/com/bacancy/ccs2androidhmi/views/HMIDashboardActivity.kt
+++ b/app/src/main/java/com/bacancy/ccs2androidhmi/views/HMIDashboardActivity.kt
@@ -6,6 +6,7 @@ import android.app.UiModeManager
 import android.app.admin.DevicePolicyManager
 import android.content.Context
 import android.content.Intent
+import android.content.res.Configuration
 import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkRequest
@@ -74,6 +75,7 @@ import com.bacancy.ccs2androidhmi.views.fragment.TestModeHomeFragment
 import com.bacancy.ccs2androidhmi.views.listener.FragmentChangeListener
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.text.SimpleDateFormat
@@ -128,7 +130,7 @@ class HMIDashboardActivity : SerialPortBaseActivityNew(), FragmentChangeListener
         super.onResume()
         observeDeviceInternetStates()
         startClockTimer()
-        manageKioskMode()
+        //manageKioskMode()
     }
 
     private fun manageKioskMode() {
@@ -232,7 +234,8 @@ class HMIDashboardActivity : SerialPortBaseActivityNew(), FragmentChangeListener
                 val abnormalErrorsList = codes.flatMap { tbErrorCodes ->
                     appViewModel.getAbnormalErrorCodesList(
                         tbErrorCodes.sourceErrorCodes,
-                        tbErrorCodes.sourceId
+                        tbErrorCodes.sourceId,
+                        tbErrorCodes.sourceErrorDateTime
                     )
                 }.toMutableList()
 
@@ -525,6 +528,16 @@ class HMIDashboardActivity : SerialPortBaseActivityNew(), FragmentChangeListener
             AppCompatDelegate.setDefaultNightMode(newNightMode)
         }
         prefHelper.setBoolean(IS_DARK_THEME, !prefHelper.getBoolean(IS_DARK_THEME, false))
+    }
+
+    override fun onNightModeChanged(mode: Int) {
+        super.onNightModeChanged(mode)
+        Log.d(TAG, "onNightModeChanged: Called")
+        lifecycleScope.launch {
+            resetPorts()
+            delay(1000)
+            setupPortsAndStartReading()
+        }
     }
 
     private fun handleClicks() {

--- a/app/src/main/java/com/bacancy/ccs2androidhmi/views/HMIDashboardActivity.kt
+++ b/app/src/main/java/com/bacancy/ccs2androidhmi/views/HMIDashboardActivity.kt
@@ -245,8 +245,9 @@ class HMIDashboardActivity : SerialPortBaseActivityNew(), FragmentChangeListener
                     )
                 }
                 val abnormalErrorsList = errorCodeDomainList.filter { it.errorCodeValue == 1 }.toMutableList()
+                val resolvedErrorsList = errorCodeDomainList.filter { it.errorCodeValue == 0 }.toMutableList()
 
-                if (abnormalErrorsList.isEmpty()) {
+                if (abnormalErrorsList.size == resolvedErrorsList.size || abnormalErrorsList.isEmpty()) {
                     sentErrorsList = mutableListOf()
                 } else {
                     val uniqueErrorsList = getUniqueItems(abnormalErrorsList, sentErrorsList)

--- a/app/src/main/java/com/bacancy/ccs2androidhmi/views/HMIDashboardActivity.kt
+++ b/app/src/main/java/com/bacancy/ccs2androidhmi/views/HMIDashboardActivity.kt
@@ -130,7 +130,7 @@ class HMIDashboardActivity : SerialPortBaseActivityNew(), FragmentChangeListener
         super.onResume()
         observeDeviceInternetStates()
         startClockTimer()
-        //manageKioskMode()
+        manageKioskMode()
     }
 
     private fun manageKioskMode() {
@@ -231,13 +231,20 @@ class HMIDashboardActivity : SerialPortBaseActivityNew(), FragmentChangeListener
             errorCodes?.let { codes ->
                 val savedMacAddress = prefHelper.getStringValue(DEVICE_MAC_ADDRESS, "")
 
-                val abnormalErrorsList = codes.flatMap { tbErrorCodes ->
-                    appViewModel.getAbnormalErrorCodesList(
-                        tbErrorCodes.sourceErrorCodes,
-                        tbErrorCodes.sourceId,
-                        tbErrorCodes.sourceErrorDateTime
+                val errorCodeDomainList = mutableListOf<ErrorCodes>()
+                codes.forEach {
+                    errorCodeDomainList.add(
+                        ErrorCodes(
+                            id = it.id,
+                            errorCodeStatus = "",
+                            errorCodeValue = it.sourceErrorValue,
+                            errorCodeName = it.sourceErrorCodes,
+                            errorCodeSource = getErrorSource(it.sourceId),
+                            errorCodeDateTime = it.sourceErrorDateTime
+                        )
                     )
-                }.toMutableList()
+                }
+                val abnormalErrorsList = errorCodeDomainList.filter { it.errorCodeValue == 1 }.toMutableList()
 
                 if (abnormalErrorsList.isEmpty()) {
                     sentErrorsList = mutableListOf()
@@ -249,6 +256,15 @@ class HMIDashboardActivity : SerialPortBaseActivityNew(), FragmentChangeListener
                     }
                 }
             }
+        }
+    }
+
+    private fun getErrorSource(sourceId: Int): String {
+        return when(sourceId){
+            0 -> "Charger"
+            1 -> "Gun 1"
+            2 -> "Gun 2"
+            else -> "Charger"
         }
     }
 

--- a/app/src/main/java/com/bacancy/ccs2androidhmi/views/adapters/ChargingHistoryListAdapter.kt
+++ b/app/src/main/java/com/bacancy/ccs2androidhmi/views/adapters/ChargingHistoryListAdapter.kt
@@ -5,9 +5,9 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.bacancy.ccs2androidhmi.R
 import com.bacancy.ccs2androidhmi.databinding.RowItemChargingHistoryBinding
 import com.bacancy.ccs2androidhmi.db.entity.TbChargingHistory
-import com.bacancy.ccs2androidhmi.util.visible
 
 class ChargingHistoryListAdapter(var onItemClick: (TbChargingHistory) -> Unit) :
     ListAdapter<TbChargingHistory, ChargingHistoryListAdapter.SampleViewHolder>(
@@ -54,6 +54,7 @@ class ChargingHistoryListAdapter(var onItemClick: (TbChargingHistory) -> Unit) :
                 tvEndSoC.text = sampleModel.endSoc + "%"
                 tvEnergyConsumption.text = sampleModel.energyConsumption + " kwh"
                 tvSessionEndReason.text = sampleModel.sessionEndReason
+                tvTotalCost.text = itemView.context.getString(R.string.lbl_gun_total_cost_in_rs, if(sampleModel.totalCost.isEmpty()) 0.0F else sampleModel.totalCost.toFloat())
             }
         }
     }

--- a/app/src/main/java/com/bacancy/ccs2androidhmi/views/adapters/ErrorCodesListAdapter.kt
+++ b/app/src/main/java/com/bacancy/ccs2androidhmi/views/adapters/ErrorCodesListAdapter.kt
@@ -5,6 +5,7 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.bacancy.ccs2androidhmi.R
 import com.bacancy.ccs2androidhmi.databinding.RowItemErrorCodesBinding
 import com.bacancy.ccs2androidhmi.models.ErrorCodes
 
@@ -45,10 +46,18 @@ class ErrorCodesListAdapter(var onItemClick: (ErrorCodes) -> Unit) :
 
         fun bind(sampleModel: ErrorCodes, position: Int) {
             binding.apply {
-                tvSerialNo.text = (position+1).toString()
+                tvSerialNo.text = (sampleModel.id).toString()
                 tvErrorDateTime.text = sampleModel.errorCodeDateTime
                 tvErrorCodeName.text = sampleModel.errorCodeName
-                tvErrorCodeStatus.text = sampleModel.errorCodeStatus
+
+                if (sampleModel.errorCodeValue == 1) {
+                    tvErrorCodeStatus.text = "Occurred"
+                    tvErrorCodeStatus.setBackgroundResource(R.drawable.bg_red_rect_with_white_border)
+                } else {
+                    tvErrorCodeStatus.text = "Resolved"
+                    tvErrorCodeStatus.setBackgroundResource(R.drawable.bg_green_rect_with_white_border)
+                }
+                tvErrorCodeSource.text = sampleModel.errorCodeSource
             }
         }
     }

--- a/app/src/main/java/com/bacancy/ccs2androidhmi/views/adapters/ErrorCodesListAdapter.kt
+++ b/app/src/main/java/com/bacancy/ccs2androidhmi/views/adapters/ErrorCodesListAdapter.kt
@@ -45,7 +45,8 @@ class ErrorCodesListAdapter(var onItemClick: (ErrorCodes) -> Unit) :
 
         fun bind(sampleModel: ErrorCodes, position: Int) {
             binding.apply {
-                tvSerialNo.text = ""+sampleModel.id
+                tvSerialNo.text = (position+1).toString()
+                tvErrorDateTime.text = sampleModel.errorCodeDateTime
                 tvErrorCodeName.text = sampleModel.errorCodeName
                 tvErrorCodeStatus.text = sampleModel.errorCodeStatus
             }

--- a/app/src/main/java/com/bacancy/ccs2androidhmi/views/fragment/ACMeterInfoFragment.kt
+++ b/app/src/main/java/com/bacancy/ccs2androidhmi/views/fragment/ACMeterInfoFragment.kt
@@ -118,7 +118,7 @@ class ACMeterInfoFragment : BaseFragment() {
             incActivePower.tvLabel.text = getString(R.string.lbl_active_power)
             incActivePower.tvValueUnit.text = getString(R.string.lbl_kw)
 
-            incTotalPower.tvLabel.text = getString(R.string.lbl_total_power)
+            incTotalPower.tvLabel.text = getString(R.string.lbl_total_export_energy)
             incTotalPower.tvValueUnit.text = getString(R.string.lbl_kwh)
         }
 

--- a/app/src/main/java/com/bacancy/ccs2androidhmi/views/fragment/GunsHomeScreenFragment.kt
+++ b/app/src/main/java/com/bacancy/ccs2androidhmi/views/fragment/GunsHomeScreenFragment.kt
@@ -155,12 +155,14 @@ class GunsHomeScreenFragment : BaseFragment() {
         }
         when (tbGunsChargingInfo.gunChargingState) {
             UNPLUGGED -> {
+                hideGunsChargingStatusUI(true)
                 binding.tvGun1State.removeBlinking()
                 shouldShowGun1SummaryDialog = false
                 binding.ivGun1Half.setImageResource(R.drawable.img_gun1_unplugged)
             }
 
             PLUGGED_IN -> {
+                hideGunsChargingStatusUI(true)
                 binding.tvGun1State.removeBlinking()
                 shouldShowGun1SummaryDialog = false
                 binding.ivGun1Half.setImageResource(R.drawable.img_gun1_plugged)
@@ -176,6 +178,7 @@ class GunsHomeScreenFragment : BaseFragment() {
             }
 
             PREPARING_FOR_CHARGING -> {
+                hideGunsChargingStatusUI(true)
                 binding.tvGun1State.removeBlinking()
                 shouldShowGun1SummaryDialog = false
                 binding.ivGun1Half.setImageResource(R.drawable.img_gun1_charging_completed)
@@ -266,12 +269,14 @@ class GunsHomeScreenFragment : BaseFragment() {
         }
         when (tbGunsChargingInfo.gunChargingState) {
             UNPLUGGED -> {
+                hideGunsChargingStatusUI(false)
                 binding.tvGun2State.removeBlinking()
                 shouldShowGun2SummaryDialog = false
                 binding.ivGun2Half.setImageResource(R.drawable.img_gun2_unplugged)
             }
 
             PLUGGED_IN -> {
+                hideGunsChargingStatusUI(false)
                 binding.tvGun2State.removeBlinking()
                 shouldShowGun2SummaryDialog = false
                 binding.ivGun2Half.setImageResource(R.drawable.img_gun2_plugged)
@@ -287,6 +292,7 @@ class GunsHomeScreenFragment : BaseFragment() {
             }
 
             PREPARING_FOR_CHARGING -> {
+                hideGunsChargingStatusUI(false)
                 binding.tvGun2State.removeBlinking()
                 shouldShowGun2SummaryDialog = false
                 binding.ivGun2Half.setImageResource(R.drawable.img_gun2_charging_completed)

--- a/app/src/main/java/com/bacancy/ccs2androidhmi/views/fragment/GunsLastChargingSummaryFragment.kt
+++ b/app/src/main/java/com/bacancy/ccs2androidhmi/views/fragment/GunsLastChargingSummaryFragment.kt
@@ -58,6 +58,7 @@ class GunsLastChargingSummaryFragment : BaseFragment() {
                 incEndSOC.tvSummaryValue.text = endSoc
                 incEnergyConsumption.tvSummaryValue.text = energyConsumption
                 incSessionEndReason.tvSummaryValue.text = sessionEndReason
+                incTotalCost.tvSummaryValue.text = getString(R.string.lbl_gun_total_cost_in_rs, if(totalCost.isEmpty()) 0.0F else totalCost.toFloat())
             }
         }
     }
@@ -140,7 +141,10 @@ class GunsLastChargingSummaryFragment : BaseFragment() {
             incSessionEndReason.tvSummaryValue.text = ""
             incSessionEndReason.root.setBackgroundColorBasedOnTheme()
 
-
+            incTotalCost.tvSummaryLabel.text = getString(R.string.lbl_total_cost)
+            incTotalCost.tvSummaryUnit.invisible()
+            incTotalCost.tvSummaryValue.text = ""
+            incTotalCost.root.setBackgroundColor(resources.getColor(R.color.light_trans_sky_blue))
         }
     }
 

--- a/app/src/main/java/com/bacancy/ccs2androidhmi/views/fragment/GunsMoreInformationFragment.kt
+++ b/app/src/main/java/com/bacancy/ccs2androidhmi/views/fragment/GunsMoreInformationFragment.kt
@@ -231,7 +231,7 @@ class GunsMoreInformationFragment : BaseFragment() {
             incDuration.tvValueUnit.invisible()
 
             incEnergyConsumption.tvLabel.text = getString(R.string.lbl_energy_consumption)
-            incEnergyConsumption.tvValueUnit.text = getString(R.string.lbl_kw)
+            incEnergyConsumption.tvValueUnit.text = getString(R.string.lbl_kwh)
 
             incGunTemperatureDCPositive.tvLabel.text = getString(R.string.lbl_gun_temp_dc_positive)
             incGunTemperatureDCPositive.tvValueUnit.text = getString(R.string.lbl_celsius)

--- a/app/src/main/java/com/bacancy/ccs2androidhmi/views/fragment/NewFaultInfoFragment.kt
+++ b/app/src/main/java/com/bacancy/ccs2androidhmi/views/fragment/NewFaultInfoFragment.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.DefaultItemAnimator
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.bacancy.ccs2androidhmi.R
 import com.bacancy.ccs2androidhmi.base.BaseFragment
@@ -45,10 +46,11 @@ class NewFaultInfoFragment : BaseFragment() {
             if (errorCodes != null) {
                 Log.d("ErrorCodes", "ErrorCodes: $errorCodes")
                 val updatedErrorCodesList = mutableListOf<ErrorCodes>()
-                errorCodes.forEach { tbErrorCodes ->
+
+                errorCodes.forEachIndexed { index, tbErrorCodes ->
                     updatedErrorCodesList.add(
                         ErrorCodes(
-                            id = tbErrorCodes.id,
+                            id = index + 1,
                             errorCodeName = tbErrorCodes.sourceErrorCodes,
                             errorCodeStatus = "",
                             errorCodeSource = getErrorCodeSource(tbErrorCodes.sourceId),
@@ -57,11 +59,13 @@ class NewFaultInfoFragment : BaseFragment() {
                         )
                     )
                 }
+
                 lifecycleScope.launch(Dispatchers.Main) {
                     if (updatedErrorCodesList.isNotEmpty()) {
                         binding.tvNoDataFound.gone()
                         binding.rvVendorErrorCodeInfo.visible()
                         allErrorCodesListAdapter.submitList(updatedErrorCodesList)
+                        binding.rvVendorErrorCodeInfo.smoothScrollToPosition(0)
                     } else {
                         binding.tvNoDataFound.visible()
                         binding.rvVendorErrorCodeInfo.gone()
@@ -92,6 +96,7 @@ class NewFaultInfoFragment : BaseFragment() {
             rvVendorErrorCodeInfo.apply {
                 layoutManager = LinearLayoutManager(requireActivity())
                 adapter = allErrorCodesListAdapter
+                itemAnimator = DefaultItemAnimator()
             }
         }
     }

--- a/app/src/main/java/com/bacancy/ccs2androidhmi/views/fragment/NewFaultInfoFragment.kt
+++ b/app/src/main/java/com/bacancy/ccs2androidhmi/views/fragment/NewFaultInfoFragment.kt
@@ -1,6 +1,7 @@
 package com.bacancy.ccs2androidhmi.views.fragment
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -12,7 +13,6 @@ import com.bacancy.ccs2androidhmi.base.BaseFragment
 import com.bacancy.ccs2androidhmi.databinding.FragmentNewFaultInformationBinding
 import com.bacancy.ccs2androidhmi.db.entity.TbErrorCodes
 import com.bacancy.ccs2androidhmi.models.ErrorCodes
-import com.bacancy.ccs2androidhmi.util.StateAndModesUtils
 import com.bacancy.ccs2androidhmi.util.gone
 import com.bacancy.ccs2androidhmi.util.visible
 import com.bacancy.ccs2androidhmi.viewmodel.AppViewModel
@@ -44,6 +44,7 @@ class NewFaultInfoFragment : BaseFragment() {
     private fun observeAllErrorCodes() {
         appViewModel.allErrorCodes.observe(requireActivity()) { errorCodes ->
             if (errorCodes != null) {
+                Log.d("ErrorCodes", "ErrorCodes: $errorCodes")
                 createCommonAbnormalErrorsList(errorCodes)
             }
         }
@@ -56,7 +57,8 @@ class NewFaultInfoFragment : BaseFragment() {
                 updatedErrorCodesList.addAll(
                     appViewModel.getAbnormalErrorCodesList(
                         tbErrorCodes.sourceErrorCodes,
-                        tbErrorCodes.sourceId
+                        tbErrorCodes.sourceId,
+                        tbErrorCodes.sourceErrorDateTime
                     )
                 )
             }

--- a/app/src/main/res/drawable/bg_green_rect_with_white_border.xml
+++ b/app/src/main/res/drawable/bg_green_rect_with_white_border.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape android:shape="rectangle" xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/green"/>
+    <stroke android:color="@color/white" android:width="1dp"/>
+</shape>

--- a/app/src/main/res/drawable/bg_red_rect_with_white_border.xml
+++ b/app/src/main/res/drawable/bg_red_rect_with_white_border.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape android:shape="rectangle" xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/red"/>
+    <stroke android:color="@color/white" android:width="1dp"/>
+</shape>

--- a/app/src/main/res/layout/common_charging_summary_dialog_item.xml
+++ b/app/src/main/res/layout/common_charging_summary_dialog_item.xml
@@ -4,7 +4,6 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:gravity="center_vertical"
-    android:paddingVertical="@dimen/_1sdp"
     android:orientation="horizontal">
 
     <TextView

--- a/app/src/main/res/layout/dialog_guns_charging_summary.xml
+++ b/app/src/main/res/layout/dialog_guns_charging_summary.xml
@@ -68,12 +68,18 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
 
+        <include
+            android:id="@+id/incSessionTotalCost"
+            layout="@layout/common_charging_summary_dialog_item"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
         <Button
             android:id="@+id/btnClose"
             style="@style/CommonButtonTheme"
             android:layout_width="wrap_content"
             android:layout_height="@dimen/_20sdp"
-            android:layout_marginTop="@dimen/_10sdp"
+            android:layout_marginTop="@dimen/_5sdp"
             android:paddingHorizontal="@dimen/_10sdp"
             android:text="@string/lbl_close"
             android:textSize="@dimen/_8ssp" />

--- a/app/src/main/res/layout/dialog_password_prompt.xml
+++ b/app/src/main/res/layout/dialog_password_prompt.xml
@@ -12,7 +12,7 @@
         android:padding="@dimen/_10sdp">
 
         <TextView
-            android:id="@+id/tvGunsHeader"
+            android:id="@+id/tvPopupTitle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/lbl_authorize_for_local_start_stop"

--- a/app/src/main/res/layout/fragment_guns_charging_history.xml
+++ b/app/src/main/res/layout/fragment_guns_charging_history.xml
@@ -46,7 +46,7 @@
             style="@style/HistoryTableHeaderTheme"
             android:layout_width="0dp"
             android:layout_height="match_parent"
-            android:layout_weight="0.60"
+            android:layout_weight="0.70"
             android:text="@string/lbl_charging_duration" />
 
         <TextView
@@ -90,6 +90,13 @@
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:text="@string/lbl_session_end_reason" />
+
+        <TextView
+            style="@style/HistoryTableHeaderTheme"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="0.80"
+            android:text="@string/lbl_total_cost" />
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_guns_charging_summary.xml
+++ b/app/src/main/res/layout/fragment_guns_charging_summary.xml
@@ -17,7 +17,7 @@
         layout="@layout/common_summary_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/_10sdp" />
+        android:layout_marginTop="@dimen/_3sdp" />
 
     <include
         android:id="@+id/incChargingDuration"
@@ -57,6 +57,12 @@
 
     <include
         android:id="@+id/incSessionEndReason"
+        layout="@layout/common_summary_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+    <include
+        android:id="@+id/incTotalCost"
         layout="@layout/common_summary_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />

--- a/app/src/main/res/layout/fragment_new_fault_information.xml
+++ b/app/src/main/res/layout/fragment_new_fault_information.xml
@@ -25,7 +25,7 @@
             style="@style/HistoryTableHeaderTheme"
             android:layout_width="0dp"
             android:layout_height="match_parent"
-            android:layout_weight="0.3"
+            android:layout_weight="0.2"
             android:text="@string/lbl_serial_number" />
 
         <TextView
@@ -39,14 +39,24 @@
             style="@style/HistoryTableHeaderTheme"
             android:layout_width="0dp"
             android:layout_height="match_parent"
-            android:layout_weight="1"
+            android:layout_weight="0.8"
+            android:paddingStart="@dimen/_20sdp"
+            android:paddingEnd="@dimen/_20sdp"
+            android:gravity="start|center"
             android:text="@string/lbl_error_desc" />
 
         <TextView
             style="@style/HistoryTableHeaderTheme"
             android:layout_width="0dp"
             android:layout_height="match_parent"
-            android:layout_weight="1"
+            android:layout_weight="0.5"
+            android:text="@string/lbl_error_status" />
+
+        <TextView
+            style="@style/HistoryTableHeaderTheme"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="0.5"
             android:text="@string/lbl_error_source" />
 
     </LinearLayout>

--- a/app/src/main/res/layout/fragment_new_fault_information.xml
+++ b/app/src/main/res/layout/fragment_new_fault_information.xml
@@ -32,6 +32,13 @@
             style="@style/HistoryTableHeaderTheme"
             android:layout_width="0dp"
             android:layout_height="match_parent"
+            android:layout_weight="0.5"
+            android:text="@string/lbl_error_time" />
+
+        <TextView
+            style="@style/HistoryTableHeaderTheme"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
             android:layout_weight="1"
             android:text="@string/lbl_error_desc" />
 

--- a/app/src/main/res/layout/fragment_test_mode_guns_detail.xml
+++ b/app/src/main/res/layout/fragment_test_mode_guns_detail.xml
@@ -76,7 +76,6 @@
             android:maxLength="3"
             android:paddingHorizontal="@dimen/_25sdp"
             android:paddingVertical="@dimen/_10sdp"
-            android:textColor="@color/white"
             android:textColorHint="@color/light_grey"
             android:textSize="@dimen/_10ssp"
             app:layout_constraintEnd_toEndOf="@id/edtGunVoltage"

--- a/app/src/main/res/layout/row_item_charging_history.xml
+++ b/app/src/main/res/layout/row_item_charging_history.xml
@@ -25,7 +25,7 @@
             style="@style/HistoryTableColumnsTheme"
             android:layout_width="0dp"
             android:layout_height="match_parent"
-            android:layout_weight="0.60"
+            android:layout_weight="0.70"
             android:text="@string/lbl_sample_ev_mac_address" />
 
         <TextView
@@ -75,6 +75,14 @@
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:text="@string/lbl_sample_ev_mac_address" />
+
+        <TextView
+            android:id="@+id/tvTotalCost"
+            style="@style/HistoryTableColumnsTheme"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="0.80"
+            android:text="@string/lbl_gun_total_cost_in_rs" />
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/row_item_error_codes.xml
+++ b/app/src/main/res/layout/row_item_error_codes.xml
@@ -10,7 +10,7 @@
         style="@style/HistoryTableColumnsTheme"
         android:layout_width="0dp"
         android:layout_height="match_parent"
-        android:layout_weight="0.3"
+        android:layout_weight="0.2"
         tools:text="1" />
 
     <TextView
@@ -26,7 +26,9 @@
         style="@style/HistoryTableColumnsTheme"
         android:layout_width="0dp"
         android:layout_height="match_parent"
-        android:layout_weight="1"
+        android:layout_weight="0.8"
+        android:gravity="start|center"
+        android:paddingStart="@dimen/_20sdp"
         tools:text="HIGH_NEUTRAL_TO_EARTH_VOLTAGE" />
 
     <TextView
@@ -34,7 +36,15 @@
         style="@style/HistoryTableColumnsTheme"
         android:layout_width="0dp"
         android:layout_height="match_parent"
-        android:layout_weight="1"
-        tools:text="Abnormal" />
+        android:layout_weight="0.5"
+        tools:text="Resolved" />
+
+    <TextView
+        android:id="@+id/tvErrorCodeSource"
+        style="@style/HistoryTableColumnsTheme"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="0.5"
+        tools:text="Charger" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/row_item_error_codes.xml
+++ b/app/src/main/res/layout/row_item_error_codes.xml
@@ -14,6 +14,14 @@
         tools:text="1" />
 
     <TextView
+        android:id="@+id/tvErrorDateTime"
+        style="@style/HistoryTableColumnsTheme"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="0.5"
+        tools:text="20-05-2024 10:49:15" />
+
+    <TextView
         android:id="@+id/tvErrorCodeName"
         style="@style/HistoryTableColumnsTheme"
         android:layout_width="0dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -135,8 +135,8 @@
     <string name="message_device_communication_error">Device Communication Error</string>
     <string name="lbl_gun_2_loading">Gun - 2 (Loading…)</string>
     <string name="lbl_gun_1_loading">Gun - 1 (Loading…)</string>
-    <string name="lbl_serial_number">Serial No.</string>
-    <string name="lbl_error_status">Status</string>
+    <string name="lbl_serial_number">Sr. No.</string>
+    <string name="lbl_error_status">Error Status</string>
     <string name="lbl_error_desc">Error description</string>
     <string name="lbl_authorize_for_local_start_stop">Authorize for Local Start/Stop</string>
     <string name="hint_enter_your_6_digit_pin">Enter your 6-digit PIN</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -86,6 +86,7 @@
     <string name="lbl_frequency_hz">Frequency (Hz)</string>
     <string name="lbl_active_power">Active Power</string>
     <string name="lbl_total_power">Total Power</string>
+    <string name="lbl_total_export_energy">Total Export Energy</string>
     <string name="lbl_gun_1">GUN - 1</string>
     <string name="lbl_gun_2">GUN - 2</string>
     <string name="lbl_percentage">%</string>
@@ -170,5 +171,9 @@
     <string name="msg_charger_is_inoperative">Charger is inoperative.</string>
     <string name="lbl_no_notifications_found">No Notifications Found.</string>
     <string name="lbl_notifications">Notifications</string>
+    <string name="lbl_total_cost">Total Cost</string>
+    <string name="title_authorize_for_local_start_stop">Authorize for Local Start/Stop</string>
+    <string name="title_authorize_for_test_mode">Authorize for Test Mode</string>
+    <string name="msg_evseready_app_not_installed">EVSEReady App Not Installed</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -175,5 +175,6 @@
     <string name="title_authorize_for_local_start_stop">Authorize for Local Start/Stop</string>
     <string name="title_authorize_for_test_mode">Authorize for Test Mode</string>
     <string name="msg_evseready_app_not_installed">EVSEReady App Not Installed</string>
+    <string name="lbl_error_time">Error Time</string>
 
 </resources>


### PR DESCRIPTION
- Shown total cost in charging summary and in charging history
- Updated Total Power label to Total Export Energy in AC meter screen
- Updated kW to kWh in energy consumption in guns info screen
- Make TestMode password protected
- Hide charging status view for other charging states than charging itself
- Updated edittext color in test mode for light and dark themes
- Updated logic to resend initial charger details to mqtt server whenever app restarts
- Added code to open EVSEReady app from our app and turn off and on kiosk mode accordingly
- Added migration in room DB for adding new field of TotalCost in last charging summary entity
- Looked into installing EVSEReady Flutter APK in HMI
- Faced some issues while opening and configuring EVSE app so coordinated with Rohan to resolve those issues
- Unit tested the EVSEReady app by changing the configurations in the app
- Updated logic to track some errors occurred and resolved states and shown them in FaultInfo screen
- Updated FaultInfo table to show Error Status row with green and red colored backgrounds to show the status of the error
- Also updated the logic to send unique occurred errors to mqtt server
- Resolved issue of Gun2 not turning on in TestMode